### PR TITLE
Ny endre-flyt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     implementation("io.ktor:ktor-server-netty:${libs.versions.ktor.get()}")
     implementation("io.ktor:ktor-server-config-yaml:${libs.versions.ktor.get()}")
     implementation(libs.bundles.postgres)
+    implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.5.2")
 
     // PDF
     implementation("io.github.openhtmltopdf:openhtmltopdf-pdfbox:1.1.21")

--- a/openapi/src/main/resources/rapportering-api.yaml
+++ b/openapi/src/main/resources/rapportering-api.yaml
@@ -185,8 +185,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Rapporteringsperiode'
-                404:
-                    description: Not Found
+                400:
+                    description: Bad request - kunne ikke endre rapporteringsperiode
+                500:
+                    description: Internal server error - Finner ikke original rapporteringsperiode
             summary: Opprett endring av rapporteringsperiode
             description: Oppretter endring av rapporteringsperiode. Returnerer rapporteringsperiode med ny id og status Endret
             operationId: post-rapporteringsperiode-id-endre

--- a/src/main/kotlin/no/nav/dagpenger/rapportering/api/RapporteringApi.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/api/RapporteringApi.kt
@@ -193,10 +193,10 @@ internal fun Application.rapporteringApi(rapporteringService: RapporteringServic
                         post {
                             val ident = call.ident()
                             val jwtToken = call.request.jwt()
-                            val id = call.getParameter("id")
+                            val id = call.getParameter("id").toLong()
 
                             rapporteringService
-                                .endreRapporteringsperiode(id.toLong(), ident, jwtToken)
+                                .startEndring(id, ident, jwtToken)
                                 .also { call.respond(HttpStatusCode.OK, it) }
                         }
                     }

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/api/RapporteringApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/api/RapporteringApiTest.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.rapportering.api
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.ktor.client.call.body
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
@@ -335,7 +336,7 @@ class RapporteringApiTest : ApiTestSetup() {
                 client.doPostAndReceive<Rapporteringsperiode>("/rapporteringsperiode/125/endre", issueToken(fnr))
             response.httpResponse.status shouldBe HttpStatusCode.OK
             with(response.body) {
-                id shouldBe 321L
+                id shouldNotBe 125L
                 dager.forEach { dag ->
                     dag.aktiviteter.forEach { aktivitet ->
                         aktivitet.type shouldBe AktivitetsType.Arbeid
@@ -377,7 +378,7 @@ class RapporteringApiTest : ApiTestSetup() {
                 client.doPostAndReceive<Rapporteringsperiode>("/rapporteringsperiode/125/endre", issueToken(fnr))
             response.httpResponse.status shouldBe HttpStatusCode.OK
             with(response.body) {
-                id shouldBe 321L
+                id shouldNotBe 125L
                 dager.forEach { dag ->
                     dag.aktiviteter.forEach { aktivitet ->
                         aktivitet.type shouldBe AktivitetsType.Arbeid
@@ -395,7 +396,7 @@ class RapporteringApiTest : ApiTestSetup() {
     fun `endring feiler hvis original rapporteringsperiode ikke finnes`() =
         setUpTestApplication {
             externalServices {
-                meldepliktAdapter(rapporteringsperioderResponse = emptyList())
+                meldepliktAdapter(sendteRapporteringsperioderResponse = emptyList())
             }
 
             val response = client.doPost("/rapporteringsperiode/123/endre", issueToken(fnr))
@@ -406,7 +407,7 @@ class RapporteringApiTest : ApiTestSetup() {
     fun `endring feiler hvis original rapporteringsperiode ikke kan endres`() =
         setUpTestApplication {
             externalServices {
-                meldepliktAdapter(rapporteringsperioderResponse = listOf(adapterRapporteringsperiode(kanEndres = false)))
+                meldepliktAdapter(sendteRapporteringsperioderResponse = listOf(adapterRapporteringsperiode(kanEndres = false)))
             }
 
             val response = client.doPost("/rapporteringsperiode/123/endre", issueToken(fnr))

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/api/RapporteringApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/api/RapporteringApiTest.kt
@@ -154,6 +154,52 @@ class RapporteringApiTest : ApiTestSetup() {
             }
         }
 
+    @Test
+    fun `kan sende inn endring med begrunnelse`() =
+        setUpTestApplication {
+            externalServices {
+                meldepliktAdapter()
+                dokarkiv()
+            }
+
+            val endreResponse = client.doPost("/rapporteringsperiode/125/endre", issueToken(fnr))
+            endreResponse.status shouldBe HttpStatusCode.OK
+            val nyId = objectMapper.readValue(endreResponse.bodyAsText(), Rapporteringsperiode::class.java).id
+
+            with(
+                client.doPost(
+                    "/rapporteringsperiode",
+                    issueToken(fnr),
+                    rapporteringsperiodeFor(id = nyId, status = Endret, begrunnelseEndring = "Endring"),
+                ),
+            ) {
+                status shouldBe HttpStatusCode.OK
+            }
+        }
+
+    @Test
+    fun `kan ikke sende inn endring uten begrunnelse`() =
+        setUpTestApplication {
+            externalServices {
+                meldepliktAdapter()
+                dokarkiv()
+            }
+
+            val endreResponse = client.doPost("/rapporteringsperiode/125/endre", issueToken(fnr))
+            endreResponse.status shouldBe HttpStatusCode.OK
+            val nyId = objectMapper.readValue(endreResponse.bodyAsText(), Rapporteringsperiode::class.java).id
+
+            with(
+                client.doPost(
+                    "/rapporteringsperiode",
+                    issueToken(fnr),
+                    rapporteringsperiodeFor(id = nyId, status = Endret),
+                ),
+            ) {
+                status shouldBe HttpStatusCode.BadRequest
+            }
+        }
+
     // Hente rapporteringsperiode med id
 
     @Test

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/service/RapporteringServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/service/RapporteringServiceTest.kt
@@ -396,12 +396,16 @@ class RapporteringServiceTest {
 
     @Test
     fun `kan sende inn endret rapporteringsperiode med begrunnelse`() {
+        val endringId = "4"
         val rapporteringsperiode = rapporteringsperiodeListe.first().copy(status = Endret, begrunnelseEndring = "Endring")
         coEvery { journalfoeringService.journalfoer(any(), any(), any(), any()) } returns mockk()
         coJustRun { rapporteringRepository.oppdaterRapporteringStatus(any(), any(), any()) }
+        coEvery { meldepliktConnector.hentEndringId(any(), any()) } returns endringId
+        coJustRun { rapporteringRepository.slettRaporteringsperiode(any()) }
+        coJustRun { rapporteringRepository.lagreRapporteringsperiodeOgDager(any(), any()) }
         coEvery { meldepliktConnector.sendinnRapporteringsperiode(any(), token) } returns
             InnsendingResponse(
-                id = rapporteringsperiode.id,
+                id = endringId.toLong(),
                 status = "OK",
                 feil = listOf(),
             )
@@ -411,7 +415,7 @@ class RapporteringServiceTest {
                 rapporteringService.sendRapporteringsperiode(rapporteringsperiode, token, ident, 4)
             }
 
-        innsendingResponse.id shouldBe rapporteringsperiode.id
+        innsendingResponse.id shouldBe endringId.toLong()
         innsendingResponse.status shouldBe "OK"
 
         verify(exactly = 1) {


### PR DESCRIPTION
Oppdaterte endepunktet `/endre` til å sjekke at meldekortet som skal endres kan endres. Lager en ny random id og lagrer meldekortet i databasen.

Oppdaterte send-endepunktet så denne tar høyde for innsending av endrede meldekort. Hvis status er Endret sjekkes det at begrunnelse er satt og det hentes en ny id for meldekortet før det sendes inn.