### PR TITLE
Kobler innsendte perioder

### DIFF
--- a/openapi/src/main/resources/rapportering-api.yaml
+++ b/openapi/src/main/resources/rapportering-api.yaml
@@ -421,6 +421,9 @@ components:
                     type: string
                 status:
                     $ref: '#/components/schemas/RapporteringsperiodeStatus'
+                mottattDato:
+                    type: string
+                    format: date
                 registrertArbeidssoker:
                     type: boolean
                 originalId:
@@ -436,6 +439,7 @@ components:
                 - Endret
                 - Innsendt
                 - Ferdig
+                - Feilet
         Problem:
             type: object
             description: Implementasjon av Problem Details for HTTP APIs [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807)

--- a/src/main/kotlin/no/nav/dagpenger/rapportering/connector/Model.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/connector/Model.kt
@@ -5,6 +5,7 @@ import no.nav.dagpenger.rapportering.connector.AdapterAktivitet.AdapterAktivitet
 import no.nav.dagpenger.rapportering.connector.AdapterAktivitet.AdapterAktivitetsType.Syk
 import no.nav.dagpenger.rapportering.connector.AdapterAktivitet.AdapterAktivitetsType.Utdanning
 import no.nav.dagpenger.rapportering.connector.AdapterRapporteringsperiodeStatus.Endret
+import no.nav.dagpenger.rapportering.connector.AdapterRapporteringsperiodeStatus.Feilet
 import no.nav.dagpenger.rapportering.connector.AdapterRapporteringsperiodeStatus.Ferdig
 import no.nav.dagpenger.rapportering.connector.AdapterRapporteringsperiodeStatus.Innsendt
 import no.nav.dagpenger.rapportering.connector.AdapterRapporteringsperiodeStatus.TilUtfylling
@@ -30,6 +31,7 @@ data class AdapterRapporteringsperiode(
     val bruttoBelop: Double?,
     val begrunnelseEndring: String?,
     val status: AdapterRapporteringsperiodeStatus,
+    val mottattDato: LocalDate?,
     val registrertArbeidssoker: Boolean?,
 )
 
@@ -38,6 +40,7 @@ enum class AdapterRapporteringsperiodeStatus {
     Endret,
     Innsendt,
     Ferdig,
+    Feilet,
 }
 
 data class AdapterPeriode(
@@ -82,7 +85,9 @@ fun AdapterRapporteringsperiode.toRapporteringsperiode(): Rapporteringsperiode =
                 Endret -> RapporteringsperiodeStatus.Endret
                 Innsendt -> RapporteringsperiodeStatus.Innsendt
                 Ferdig -> RapporteringsperiodeStatus.Ferdig
+                Feilet -> RapporteringsperiodeStatus.Feilet
             },
+        mottattDato = this.mottattDato,
         begrunnelseEndring = this.begrunnelseEndring,
         registrertArbeidssoker = this.registrertArbeidssoker,
         originalId = null,
@@ -123,7 +128,9 @@ fun Rapporteringsperiode.toAdapterRapporteringsperiode(): AdapterRapporteringspe
                 RapporteringsperiodeStatus.Endret -> Endret
                 RapporteringsperiodeStatus.Innsendt -> Innsendt
                 RapporteringsperiodeStatus.Ferdig -> Ferdig
+                RapporteringsperiodeStatus.Feilet -> Feilet
             },
+        mottattDato = this.mottattDato,
         registrertArbeidssoker = this.registrertArbeidssoker,
     )
 

--- a/src/main/kotlin/no/nav/dagpenger/rapportering/model/Rapporteringsperiode.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/model/Rapporteringsperiode.kt
@@ -18,6 +18,7 @@ data class Rapporteringsperiode(
     val bruttoBelop: Double?,
     val begrunnelseEndring: String?,
     val status: RapporteringsperiodeStatus,
+    val mottattDato: LocalDate?,
     val registrertArbeidssoker: Boolean?,
     val originalId: Long?,
     val rapporteringstype: String?,
@@ -67,7 +68,9 @@ fun Rapporteringsperiode.toResponse(): RapporteringsperiodeResponse =
                 RapporteringsperiodeStatus.Endret -> RapporteringsperiodeStatusResponse.Endret
                 RapporteringsperiodeStatus.Innsendt -> RapporteringsperiodeStatusResponse.Innsendt
                 RapporteringsperiodeStatus.Ferdig -> RapporteringsperiodeStatusResponse.Ferdig
+                RapporteringsperiodeStatus.Feilet -> RapporteringsperiodeStatusResponse.Feilet
             },
+        mottattDato = this.mottattDato,
         registrertArbeidssoker = this.registrertArbeidssoker,
         originalId = this.originalId?.toString(),
         rapporteringstype = this.rapporteringstype,

--- a/src/main/kotlin/no/nav/dagpenger/rapportering/model/RapporteringsperiodeStatus.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/model/RapporteringsperiodeStatus.kt
@@ -5,4 +5,5 @@ enum class RapporteringsperiodeStatus {
     Endret,
     Innsendt,
     Ferdig,
+    Feilet,
 }

--- a/src/main/kotlin/no/nav/dagpenger/rapportering/repository/RapporteringRepositoryPostgres.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/repository/RapporteringRepositoryPostgres.kt
@@ -463,6 +463,7 @@ private fun Row.toRapporteringsperiode() =
         begrunnelseEndring = stringOrNull("begrunnelse_endring"),
         originalId = longOrNull("original_id"),
         rapporteringstype = stringOrNull("rapporteringstype"),
+        mottattDato = localDateOrNull("mottatt_dato"),
     )
 
 private fun Row.toDagPair(): Pair<UUID, Dag> =

--- a/src/main/resources/db/migration/V1__CREATE_TABLES.sql
+++ b/src/main/resources/db/migration/V1__CREATE_TABLES.sql
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS rapporteringsperiode
     registrert_arbeidssoker BOOLEAN         NULL,
     status                  VARCHAR         NOT NULL,
     original_id             BIGINT          NULL,
-    rapporteringstype       VARCHAR         NULL
+    rapporteringstype       VARCHAR         NULL,
+    mottatt_dato            DATE            NULL
 );
 
 CREATE TABLE IF NOT EXISTS dag

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/api/ApiTestUtils.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/api/ApiTestUtils.kt
@@ -105,6 +105,7 @@ fun rapporteringsperiodeFor(
     begrunnelseEndring: String? = null,
     originalId: Long? = null,
     rapporteringstype: String? = null,
+    mottattDato: LocalDate? = null,
 ) = Rapporteringsperiode(
     id = id,
     periode = Periode(fraOgMed = fraOgMed, tilOgMed = tilOgMed),
@@ -125,4 +126,5 @@ fun rapporteringsperiodeFor(
     begrunnelseEndring = begrunnelseEndring,
     originalId = originalId,
     rapporteringstype = rapporteringstype,
+    mottattDato = mottattDato,
 )

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/api/RapporteringApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/api/RapporteringApiTest.kt
@@ -675,7 +675,8 @@ class RapporteringApiTest : ApiTestSetup() {
                                 id = 125L,
                                 fraOgMed = 1.januar(2024),
                                 aktivitet = defaultAdapterAktivitet.copy(uuid = UUID.randomUUID()),
-                                status = AdapterRapporteringsperiodeStatus.Innsendt,
+                                status = AdapterRapporteringsperiodeStatus.Endret,
+                                mottattDato = 14.januar(2024),
                             ),
                             adapterRapporteringsperiode(
                                 id = 126L,
@@ -683,6 +684,7 @@ class RapporteringApiTest : ApiTestSetup() {
                                 aktivitet = defaultAdapterAktivitet.copy(uuid = UUID.randomUUID()),
                                 status = AdapterRapporteringsperiodeStatus.Innsendt,
                                 begrunnelseEndring = "En god begrunnelse",
+                                mottattDato = 15.januar(2024),
                             ),
                             adapterRapporteringsperiode(
                                 id = 127L,
@@ -695,18 +697,21 @@ class RapporteringApiTest : ApiTestSetup() {
                                 fraOgMed = 15.januar(2024),
                                 aktivitet = defaultAdapterAktivitet.copy(uuid = UUID.randomUUID()),
                                 status = AdapterRapporteringsperiodeStatus.Innsendt,
+                                mottattDato = 20.januar(2024),
                             ),
                             adapterRapporteringsperiode(
                                 id = 129L,
                                 fraOgMed = 29.januar(2024),
                                 aktivitet = defaultAdapterAktivitet.copy(uuid = UUID.randomUUID()),
                                 status = AdapterRapporteringsperiodeStatus.Innsendt,
+                                mottattDato = 10.februar(2024),
                             ),
                             adapterRapporteringsperiode(
                                 id = 130L,
                                 fraOgMed = 12.februar(2024),
                                 aktivitet = defaultAdapterAktivitet.copy(uuid = UUID.randomUUID()),
-                                status = AdapterRapporteringsperiodeStatus.Innsendt,
+                                status = AdapterRapporteringsperiodeStatus.Endret,
+                                mottattDato = 24.februar(2024),
                             ),
                             adapterRapporteringsperiode(
                                 id = 131L,
@@ -714,6 +719,7 @@ class RapporteringApiTest : ApiTestSetup() {
                                 aktivitet = defaultAdapterAktivitet.copy(uuid = UUID.randomUUID()),
                                 status = AdapterRapporteringsperiodeStatus.Innsendt,
                                 begrunnelseEndring = "En god begrunnelse",
+                                mottattDato = 25.februar(2024),
                             ),
                         ),
                 )
@@ -851,6 +857,7 @@ class RapporteringApiTest : ApiTestSetup() {
         bruttoBelop: Double? = null,
         registrertArbeidssoker: Boolean? = null,
         begrunnelseEndring: String? = null,
+        mottattDato: LocalDate? = null,
     ) = AdapterRapporteringsperiode(
         id = id,
         periode =
@@ -873,6 +880,7 @@ class RapporteringApiTest : ApiTestSetup() {
         bruttoBelop = bruttoBelop,
         registrertArbeidssoker = registrertArbeidssoker,
         begrunnelseEndring = begrunnelseEndring,
+        mottattDato = mottattDato,
     )
 
     private fun person(

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/connector/MeldepliktConnectorTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/connector/MeldepliktConnectorTest.kt
@@ -353,6 +353,7 @@ class MeldepliktConnectorTest {
                 0.0,
                 null,
                 TilUtfylling,
+                mottattDato = null,
                 true,
                 originalId = null,
                 rapporteringstype = null,

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/repository/RapporteringRepositoryPostgresTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/repository/RapporteringRepositoryPostgresTest.kt
@@ -474,6 +474,7 @@ fun getRapporteringsperiode(
     status: RapporteringsperiodeStatus = TilUtfylling,
     registrertArbeidssoker: Boolean? = null,
     begrunnelseEndring: String? = null,
+    mottattDato: LocalDate? = null,
 ) = Rapporteringsperiode(
     id = id,
     periode = periode,
@@ -487,6 +488,7 @@ fun getRapporteringsperiode(
     begrunnelseEndring = begrunnelseEndring,
     originalId = null,
     rapporteringstype = null,
+    mottattDato = mottattDato,
 )
 
 private fun getDager(

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/service/JournalfoeringServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/service/JournalfoeringServiceTest.kt
@@ -318,6 +318,7 @@ class JournalfoeringServiceTest {
             0.0,
             null,
             if (endring) RapporteringsperiodeStatus.Endret else TilUtfylling,
+            LocalDate.now(),
             true,
             null,
             null,

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/service/RapporteringServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/service/RapporteringServiceTest.kt
@@ -382,8 +382,21 @@ class RapporteringServiceTest {
     fun `liste med innsendte rapporteringsperioder blir sortert riktig med endret meldekort før originalt meldekort`() {
         val perioderFraArena =
             rapporteringsperiodeListe
-                .map { it.copy(status = Innsendt, kanSendes = false, kanEndres = true) }
-                .toAdapterRapporteringsperioder() +
+                .map {
+                    it.copy(
+                        status =
+                            if (it.id ==
+                                3L
+                            ) {
+                                Endret
+                            } else {
+                                Innsendt
+                            },
+                        kanSendes = false,
+                        kanEndres = true,
+                        mottattDato = it.kanSendesFra,
+                    )
+                }.toAdapterRapporteringsperioder() +
                 rapporteringsperiodeListe
                     .first()
                     .copy(
@@ -391,6 +404,7 @@ class RapporteringServiceTest {
                         status = Innsendt,
                         kanSendes = false,
                         begrunnelseEndring = "Korrigert",
+                        mottattDato = LocalDate.now(),
                     ).toAdapterRapporteringsperiode()
         coEvery { meldepliktConnector.hentInnsendteRapporteringsperioder(any(), any()) } returns perioderFraArena
         coEvery { rapporteringRepository.hentLagredeRapporteringsperioder(any()) } returns
@@ -654,6 +668,7 @@ fun lagRapporteringsperiode(
     begrunnelseEndring = null,
     originalId = null,
     rapporteringstype = null,
+    mottattDato = null,
 )
 
 private fun getDager(


### PR DESCRIPTION
- Legger til ny statuse Feilet.
- Legger til mottatt dato. Denne er nullable, men kreves ved henting av innsendte perioder.
- Ved henting av innsendte rapporteringsperioder kobles alle korrigeringer mot original periode