### PR TITLE
Optimaliserer hent og oppdatering av kanSendes

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/rapportering/repository/RapporteringRepository.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/repository/RapporteringRepository.kt
@@ -36,6 +36,8 @@ interface RapporteringRepository {
 
     suspend fun hentAktiviteter(dagId: UUID): List<Aktivitet>
 
+    suspend fun hentKanSendes(rapporteringId: Long): Boolean?
+
     suspend fun lagreRapporteringsperiodeOgDager(
         rapporteringsperiode: Rapporteringsperiode,
         ident: String,
@@ -62,6 +64,12 @@ interface RapporteringRepository {
         rapporteringId: Long,
         ident: String,
         begrunnelse: String,
+    )
+
+    suspend fun settKanSendes(
+        rapporteringId: Long,
+        ident: String,
+        kanSendes: Boolean,
     )
 
     suspend fun oppdaterRapporteringstype(

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/api/RapporteringApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/api/RapporteringApiTest.kt
@@ -171,10 +171,20 @@ class RapporteringApiTest : ApiTestSetup() {
         setUpTestApplication {
             externalServices {
                 meldepliktAdapter(
+                    rapporteringsperioderResponse =
+                        listOf(
+                            adapterRapporteringsperiode(
+                                id = 123L,
+                                aktivitet = defaultAdapterAktivitet.copy(uuid = UUID.randomUUID()),
+                                status = AdapterRapporteringsperiodeStatus.TilUtfylling,
+                            ),
+                        ),
                     sendInnResponseStatus = HttpStatusCode.InternalServerError,
                     sendInnResponse = null,
                 )
             }
+
+            client.doPost("/rapporteringsperiode/123/start", issueToken(fnr))
 
             with(client.doPost("/rapporteringsperiode", issueToken(fnr), rapporteringsperiodeFor(registrertArbeidssoker = true))) {
                 status shouldBe HttpStatusCode.InternalServerError

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/service/RapporteringServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/service/RapporteringServiceTest.kt
@@ -499,7 +499,8 @@ class RapporteringServiceTest {
     fun `kan sende inn rapporteringsperiode`() {
         val rapporteringsperiode = rapporteringsperiodeListe.first().copy(registrertArbeidssoker = true)
         coEvery { journalfoeringService.journalfoer(any(), any(), any(), any(), any()) } returns mockk()
-        coEvery { rapporteringRepository.hentRapporteringsperiode(any(), any()) } returns null
+        coEvery { rapporteringRepository.hentKanSendes(any()) } returns true
+        coJustRun { rapporteringRepository.settKanSendes(rapporteringsperiode.id, ident, false) }
         coJustRun { rapporteringRepository.oppdaterPeriodeEtterInnsending(rapporteringsperiode.id, ident, any(), false, any(), false) }
         coJustRun { rapporteringRepository.oppdaterPeriodeEtterInnsending(rapporteringsperiode.id, ident, true, false, Innsendt) }
         coEvery { meldepliktConnector.hentPerson(any(), any()) } returns Person(1L, "TESTESSEN", "TEST", "NO", "EMELD")
@@ -550,7 +551,7 @@ class RapporteringServiceTest {
 
     @Test
     fun `kan ikke sende inn rapporteringsperiode som ikke kan sendes`() {
-        coEvery { rapporteringRepository.hentRapporteringsperiode(any(), any()) } returns null
+        coEvery { rapporteringRepository.hentKanSendes(any()) } returns false
 
         shouldThrow<BadRequestException> {
             runBlocking {
@@ -577,7 +578,8 @@ class RapporteringServiceTest {
                 registrertArbeidssoker = true,
             )
         coEvery { journalfoeringService.journalfoer(any(), any(), any(), any(), any()) } returns mockk()
-        coEvery { rapporteringRepository.hentRapporteringsperiode(any(), any()) } returns null
+        coEvery { rapporteringRepository.hentKanSendes(any()) } returns true
+        coJustRun { rapporteringRepository.settKanSendes(rapporteringsperiode.id, ident, false) }
         coJustRun { rapporteringRepository.oppdaterPeriodeEtterInnsending(any(), any(), any(), any(), any()) }
         coJustRun { rapporteringRepository.oppdaterPeriodeEtterInnsending(any(), any(), any(), any(), any(), false) }
         coEvery { meldepliktConnector.hentEndringId(any(), any()) } returns endringId
@@ -635,7 +637,8 @@ class RapporteringServiceTest {
 
     @Test
     fun `kan ikke sende inn endret rapporteringsperiode uten begrunnelse`() {
-        coEvery { rapporteringRepository.hentRapporteringsperiode(any(), any()) } returns null
+        coEvery { rapporteringRepository.hentKanSendes(any()) } returns true
+        coJustRun { rapporteringRepository.settKanSendes(any(), any(), false) }
 
         shouldThrow<BadRequestException> {
             runBlocking {


### PR DESCRIPTION
Lager to nye repository-funksjoner. En for henting av kanSendes-feltet og en for oppdatering av dette feltet.

I RapporteringService har jeg flyttet oppdatering av kanSendes til rett etter at vi sjekker om perioden kan sendes.