### PR TITLE
Egen midlertidig journalføring job

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/rapportering/jobs/JobUtils.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/jobs/JobUtils.kt
@@ -12,7 +12,6 @@ fun isLeader(
     httpClient: HttpClient,
     logger: KLogger,
 ): Boolean {
-    // var leader = ""
     val hostname: String = InetAddress.getLocalHost().hostName
 
     val leader: String =

--- a/src/main/kotlin/no/nav/dagpenger/rapportering/jobs/JobUtils.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/jobs/JobUtils.kt
@@ -1,0 +1,32 @@
+package no.nav.dagpenger.rapportering.jobs
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import kotlinx.coroutines.runBlocking
+import mu.KLogger
+import no.nav.dagpenger.rapportering.model.Leader
+import java.net.InetAddress
+
+fun isLeader(
+    httpClient: HttpClient,
+    logger: KLogger,
+): Boolean {
+    // var leader = ""
+    val hostname: String = InetAddress.getLocalHost().hostName
+
+    val leader: String =
+        try {
+            val electorUrl = System.getenv("ELECTOR_GET_URL")
+
+            runBlocking {
+                val leaderJson: Leader = httpClient.get(electorUrl).body()
+                leaderJson.name
+            }
+        } catch (e: Exception) {
+            logger.error(e) { "Kunne ikke sjekke leader" }
+            return true // Det er bedre å få flere pod'er til å starte jobben enn ingen
+        }
+
+    return hostname == leader
+}

--- a/src/main/kotlin/no/nav/dagpenger/rapportering/jobs/MidlertidigJournalføringJob.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/jobs/MidlertidigJournalføringJob.kt
@@ -1,0 +1,46 @@
+package no.nav.dagpenger.rapportering.jobs
+
+import io.ktor.client.HttpClient
+import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.runBlocking
+import mu.KotlinLogging
+import no.nav.dagpenger.rapportering.metrics.JobbkjoringMetrikker
+import no.nav.dagpenger.rapportering.service.JournalfoeringService
+import java.util.Timer
+import java.util.TimerTask
+import kotlin.time.measureTime
+
+internal class MidlertidigJournalføringJob(
+    private val httpClient: HttpClient,
+    meterRegistry: MeterRegistry,
+    private val delay: Long = 10000,
+    // 5 minutes by default
+    private val resendInterval: Long = 300_000L,
+) {
+    private val logger = KotlinLogging.logger {}
+    private val metrikker: JobbkjoringMetrikker = JobbkjoringMetrikker(meterRegistry, this::class.simpleName!!)
+
+    internal fun start(journalføringService: JournalfoeringService) {
+        val timer = Timer()
+        val timerTask: TimerTask =
+            object : TimerTask() {
+                override fun run() {
+                    try {
+                        var rowsAffected: Int
+                        val tidBrukt =
+                            measureTime {
+                                rowsAffected = runBlocking { journalføringService.journalfoerPaaNytt() }
+                            }
+                        metrikker.jobbFullfort(tidBrukt, rowsAffected)
+                    } catch (e: Exception) {
+                        logger.warn(e) { "JournalfoerPaaNytt feilet" }
+                        metrikker.jobbFeilet()
+                    }
+                }
+            }
+        if (isLeader(httpClient, logger)) {
+            logger.info { "Pod er leader. Setter opp jobb for å sende journalposter på nytt" }
+            timer.schedule(timerTask, delay, resendInterval)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/api/ApiTestSetup.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/api/ApiTestSetup.kt
@@ -191,7 +191,6 @@ open class ApiTestSetup {
                         journalfoeringRepository,
                         kallLoggService,
                         httpClient,
-                        meterRegistry,
                     ),
                     kallLoggService,
                     arbeidssoekerService,

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/service/JournalfoeringServiceTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/service/JournalfoeringServiceTest.kt
@@ -42,7 +42,6 @@ import no.nav.dagpenger.rapportering.model.Rapporteringsperiode
 import no.nav.dagpenger.rapportering.model.RapporteringsperiodeStatus.TilUtfylling
 import no.nav.dagpenger.rapportering.repository.JournalfoeringRepository
 import no.nav.dagpenger.rapportering.repository.Postgres.database
-import no.nav.dagpenger.rapportering.utils.MetricsTestUtil.meterRegistry
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -116,7 +115,6 @@ class JournalfoeringServiceTest {
                 journalfoeringRepository,
                 kallLoggService,
                 createHttpClient(mockPdfGeneratorEngine),
-                meterRegistry,
             )
 
         // Prøver å journalføre
@@ -176,7 +174,6 @@ class JournalfoeringServiceTest {
                 journalfoeringRepository,
                 kallLoggService,
                 createHttpClient(mockPdfGeneratorEngine),
-                meterRegistry,
             )
 
         // Prøver å journalføre
@@ -262,7 +259,6 @@ class JournalfoeringServiceTest {
                 journalfoeringRepository,
                 kallLoggService,
                 createHttpClient(mockPdfGeneratorEngine),
-                meterRegistry,
             )
 
         val rapporteringsperiode = createRapporteringsperiode(endring)
@@ -338,7 +334,12 @@ class JournalfoeringServiceTest {
         val jsonNode = objectMapper.readTree(message)
 
         jsonNode.get("@event_name").asText() shouldBe "behov"
-        jsonNode.get("@behov").asIterable().iterator().next().asText() shouldBe MineBehov.JournalføreRapportering.name
+        jsonNode
+            .get("@behov")
+            .asIterable()
+            .iterator()
+            .next()
+            .asText() shouldBe MineBehov.JournalføreRapportering.name
 
         val behov = jsonNode.get(MineBehov.JournalføreRapportering.name)
         behov.get("periodeId").asInt() shouldBe 1


### PR DESCRIPTION
Som følge av en feil 4. mars begynte dp-rapportering å skru av rapids and rivers i appen. Feilen viste seg å komme fra `lagreJournalpostData()` i `JournalføringRepositoryPostgres`, da `validateRowsAffected()` feilet med meldingen "Expected 1 but got 0". Jeg tolker det som at journalposten allerede fantes i databasen. Teorien min for hvordan dette kan skje er at vi har sendt journalposter dobelt (begge poddene har kjørt "ryddejobben" for midlertidige journalposter) og vi har derfor fått to svar som vi da prøver å inserte i tabellen. Jeg kjenner ikke journalføring så veldig godt, så vi må se litt på dette sammen @igorweber.

Denne PR-en tar i bruk leader election sånn at kun en pod kjører `journalføringService.journalfoerPaaNytt()`.