### PR TITLE
Fikser korrigeringsflyt når person har ansvarlig system dp

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/rapportering/model/KorrigerMeldekortHendelse.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/model/KorrigerMeldekortHendelse.kt
@@ -1,0 +1,13 @@
+package no.nav.dagpenger.rapportering.model
+
+import java.time.LocalDate
+
+data class KorrigerMeldekortHendelse(
+    val ident: String,
+    val originalMeldekortId: String,
+    val periode: Periode,
+    val dager: List<PeriodeData.PeriodeDag>,
+    val kilde: PeriodeData.Kilde,
+    val begrunnelse: String,
+    val meldedato: LocalDate? = null,
+)

--- a/src/main/kotlin/no/nav/dagpenger/rapportering/model/Rapporteringsperiode.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/model/Rapporteringsperiode.kt
@@ -129,3 +129,17 @@ fun List<Dag>.toPeriodeDager(arbeidssøkerperioder: List<ArbeidssøkerperiodeRes
                 } != null,
         )
     }
+
+fun PeriodeData.toKorrigerMeldekortHendelse(): KorrigerMeldekortHendelse =
+    KorrigerMeldekortHendelse(
+        ident = ident,
+        originalMeldekortId =
+            korrigeringAv
+                ?: throw IllegalStateException("korrigeringAv kan ikke være null ved opprettelse av KorrigerMeldekortHendelse"),
+        periode = periode,
+        dager = dager,
+        kilde = kilde ?: throw IllegalStateException("kilde kan ikke være null ved opprettelse av KorrigerMeldekortHendelse"),
+        begrunnelse =
+            begrunnelseEndring
+                ?: throw IllegalStateException("begrunnelseEndring kan ikke være null ved opprettelse av KorrigerMeldekortHendelse"),
+    )

--- a/src/main/kotlin/no/nav/dagpenger/rapportering/service/MeldekortregisterService.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/service/MeldekortregisterService.kt
@@ -12,6 +12,7 @@ import no.nav.dagpenger.rapportering.config.Configuration.defaultObjectMapper
 import no.nav.dagpenger.rapportering.connector.HttpClientUtils
 import no.nav.dagpenger.rapportering.metrics.ActionTimer
 import no.nav.dagpenger.rapportering.model.InnsendingResponse
+import no.nav.dagpenger.rapportering.model.KorrigerMeldekortHendelse
 import no.nav.dagpenger.rapportering.model.PeriodeData
 
 class MeldekortregisterService(
@@ -84,6 +85,31 @@ class MeldekortregisterService(
                     .also {
                         logger.info { "Kall til meldekortregister for å sende periode ga status ${it.status}" }
                         sikkerlogg.info { "Kall til meldekortregister for å sende periode $id ga status ${it.status}" }
+                    }
+
+            val status =
+                if (result.status == HttpStatusCode.OK) {
+                    "OK"
+                } else {
+                    "FEIL"
+                }
+
+            InnsendingResponse(id, status, emptyList())
+        }
+
+    suspend fun sendKorrigertMeldekort(
+        korrigertMeldekort: KorrigerMeldekortHendelse,
+        token: String,
+    ): InnsendingResponse =
+        withContext(Dispatchers.IO) {
+            val id = korrigertMeldekort.originalMeldekortId
+
+            val result =
+                httpClientUtils
+                    .post("/meldekort/$id/korriger", token, "meldekortregister-korrigerMeldekort", korrigertMeldekort)
+                    .also {
+                        logger.info { "Kall til meldekortregister for å sende korrigert meldekort ga status ${it.status}" }
+                        sikkerlogg.info { "Kall til meldekortregister for å sende korrigert meldekort $id ga status ${it.status}" }
                     }
 
             val status =


### PR DESCRIPTION
Siden meldekortregisteret forventer en korrigertMeldekortHendelse og ikke oppretter en id for det nye korrigerte meldekortet før denne hendelsen sendes inn, endre her flyten slik at vi kan sende inn korrigeringer via dp-rapportering hvis bruker har ansvarlig system DP.