### PR TITLE
Justere memory limit og memory request

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -68,8 +68,8 @@ spec:
       value: "{{ PDL_API_SCOPE }}"
     - name: DP_RAPPORTERING_FRONTEND_URL
       value: "{{ DP_RAPPORTERING_FRONTEND_URL }}"
-    - name: JDK_JAVA_OPTIONS # Bytter GC og lar JVMen se at det er flere CPU kjerner
-      value: -XX:+UseParallelGC -XX:ActiveProcessorCount=4
+    - name: JDK_JAVA_OPTIONS # Bytter GC, lar JVMen se at det er flere CPU kjerner og styrer heap-storrelse via MaxRAMPercentage (https://nav-it.slack.com/archives/C5KUST8N6/p1714054537557279)
+      value: -XX:+UseParallelGC -XX:MaxRAMPercentage=50.0 -XX:ActiveProcessorCount=4
   gcp:
       sqlInstances:
         - type: POSTGRES_15
@@ -140,7 +140,7 @@ spec:
       memory: 1024Mi
     requests:
       cpu: 198m
-      memory: 512Mi
+      memory: 768Mi
 
   observability:
     logging:


### PR DESCRIPTION
Øker allokert minne fordi appen ligger på over 100% i minnebruk. Gir JVM tilgang på 50% av memory limit (default er 25%) for å fikse OutOfMemoryError: Java heap space i prod.