### PR TITLE
Ignorer Ktor 3.5.0

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,7 +22,7 @@ updates:
                     - "minor"
                     - "patch"
         ignore:
-            -   dependency-name: "io.ktor.*"
+            -   dependency-name: "io.ktor:*"
                 versions: [ "3.5.0" ]
         cooldown:
             default-days: 7

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,25 +1,28 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "10:05"
-      timezone: "Europe/Oslo"
-    cooldown:
-      default-days: 7
-  # Maintain dependencies for gradle
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "10:05"
-      timezone: "Europe/Oslo"
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-    cooldown:
-      default-days: 7
+    # Maintain dependencies for GitHub Actions
+    -   package-ecosystem: "github-actions"
+        directory: "/"
+        schedule:
+            interval: "daily"
+            time: "10:05"
+            timezone: "Europe/Oslo"
+        cooldown:
+            default-days: 7
+    # Maintain dependencies for gradle
+    -   package-ecosystem: "gradle"
+        directory: "/"
+        schedule:
+            interval: "daily"
+            time: "10:05"
+            timezone: "Europe/Oslo"
+        groups:
+            minor-and-patch:
+                update-types:
+                    - "minor"
+                    - "patch"
+        ignore:
+            -   dependency-name: "io.ktor.*"
+                versions: [ "3.5.0" ]
+        cooldown:
+            default-days: 7


### PR DESCRIPTION
På grunn av denne: https://github.com/ktorio/ktor/issues/5651 Vi venter på 3.5.1, hvor dette er fikset. Dependabot insisterer på å oppdatere den, men vi har ikke så lyst. Nå som vi bruker grouped dependencies, så kan vi ikke be Dependabot å ignorere en dependency vha kommandoer her.