### PR TITLE
Forbedret feilhåndtering av kall mot personregisteret.

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/rapportering/connector/PersonregisterConnector.kt
+++ b/src/main/kotlin/no/nav/dagpenger/rapportering/connector/PersonregisterConnector.kt
@@ -16,8 +16,6 @@ import no.nav.dagpenger.rapportering.config.Configuration
 import no.nav.dagpenger.rapportering.config.Configuration.defaultObjectMapper
 import no.nav.dagpenger.rapportering.metrics.ActionTimer
 import no.nav.dagpenger.rapportering.utils.Sikkerlogg
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 class PersonregisterConnector(
     val personregisterUrl: String = Configuration.personregisterUrl,
@@ -45,12 +43,26 @@ class PersonregisterConnector(
                         Sikkerlogg.info { "Kall til personregister for å hente personstatus for $ident ga status ${it.status}" }
                     }
 
-            if (result.status == HttpStatusCode.NotFound) {
-                null
-            } else {
-                result
-                    .bodyAsText()
-                    .let { defaultObjectMapper.readValue(it, Personstatus::class.java) }
+            when (result.status) {
+                HttpStatusCode.NotFound -> {
+                    null
+                }
+
+                HttpStatusCode.OK -> {
+                    result
+                        .bodyAsText()
+                        .let { defaultObjectMapper.readValue(it, Personstatus::class.java) }
+                }
+
+                else -> {
+                    val melding = result.bodyAsText()
+                    Sikkerlogg.error {
+                        "Uforventet status ved henting av personstatus for $ident: ${result.status.value} - $melding"
+                    }
+                    throw RuntimeException(
+                        "Uforventet status ved henting av personstatus: ${result.status.value}",
+                    )
+                }
             }
         }
 
@@ -62,30 +74,6 @@ class PersonregisterConnector(
             val personstatus = hentPersonstatus(ident, subjectToken)
 
             personstatus?.status ?: Brukerstatus.IKKE_DAGPENGERBRUKER
-        }
-
-    suspend fun oppdaterPersonstatus(
-        ident: String,
-        subjectToken: String,
-        datoFra: LocalDate,
-    ): Unit =
-        withContext(Dispatchers.IO) {
-            try {
-                httpClientUtils
-                    .post(
-                        "/personstatus",
-                        subjectToken,
-                        "personregister-oppdaterPersonstatus",
-                        ContentType.Text.Plain,
-                        datoFra.format(DateTimeFormatter.ISO_LOCAL_DATE),
-                    ).also {
-                        logger.info { "Kall til personregister for å oppdatere personstatus ga status ${it.status}" }
-                        Sikkerlogg.info { "Kall til personregister for å oppdatere personstatus for $ident ga status ${it.status}" }
-                    }
-            } catch (e: Exception) {
-                logger.error(e) { "Feil ved sending av data til personregister" }
-                throw e
-            }
         }
 
     suspend fun hentSisteSakId(ident: String): String? =

--- a/src/test/kotlin/no/nav/dagpenger/rapportering/connector/PersonregisterConnectorTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/rapportering/connector/PersonregisterConnectorTest.kt
@@ -1,6 +1,8 @@
 package no.nav.dagpenger.rapportering.connector
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.rapportering.api.ApiTestSetup.Companion.setEnvConfig
@@ -10,7 +12,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import java.time.LocalDate
 
 class PersonregisterConnectorTest {
     private val testTokenXProvider: (token: String) -> String = { _ -> "testToken" }
@@ -93,6 +94,18 @@ class PersonregisterConnectorTest {
     }
 
     @Test
+    fun `hentPersonstatus kaster exception ved uforventet status`() {
+        val connector = personregisterConnector(HttpStatusCode.InternalServerError)
+
+        val exception =
+            shouldThrow<RuntimeException> {
+                runBlocking { connector.hentPersonstatus(ident, subjectToken) }
+            }
+
+        exception.message shouldContain "500"
+    }
+
+    @Test
     fun `hentBrukerstatus returnerer IKKE_DAGPENGERBRUKER hvis 404 Not Found`() {
         val connector = personregisterConnector(HttpStatusCode.NotFound)
 
@@ -144,15 +157,6 @@ class PersonregisterConnectorTest {
             }
 
         response shouldBe Brukerstatus.DAGPENGERBRUKER
-    }
-
-    @Test
-    fun `oppdaterPersonstatus fungerer`() {
-        val connector = personregisterConnector(HttpStatusCode.OK)
-
-        runBlocking {
-            connector.oppdaterPersonstatus(ident, subjectToken, LocalDate.now())
-        }
     }
 
     @Test


### PR DESCRIPTION
Feilmeldingen fra apiet logges og mislykkede forsøk på å parse responsen unngås. Funksjonen for oppdaterPersonstatus var ubrukt og fjernes.